### PR TITLE
Adds lock/unlock feature to terraform remote

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+# This make file
+ENV = $(shell echo `grep "^environment" terraform.tfvars | cut -d '=' -f2 | tr -d ' ' |tr -d '"'`)
+REGION = $(shell echo `grep "^region" terraform.tfvars | cut -d '=' -f2 | tr -d ' ' | tr -d '"'`)
+
+# Set the following environment variables before running the plan
+ACCESS_KEY_ID = $(AWS_ACCESS_KEY_ID)
+SECRET_ACCESS_KEY = $(AWS_SECRET_ACCESS_KEY)
+AWS_REGION = $(strip $(AWS_DEFAULT_REGION))
+TFSTATE_BUCKET=$(S3_BUCKET_NAME)-$(AWS_REGION)
+TFSTATE_FILE=terraform.tfstate #This can be a variable as well.
+
+
+.PHONY: plan
+.PHONY: check-prereq config plan deploy
+
+#
+# Do the following steps prior to running the environment setup
+#   - Install tools in PATH: terraform
+
+check-prereq:
+	@echo "check pre-requisites ..."
+	command -v terraform >/dev/null 2>&1 || { echo "terraform is not in PATH.  Aborting." >&2; exit 1; }
+
+#
+# Set the following environment variable prior to config, plan and apply
+#  AWS_DEFAULT_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+#
+config:
+	@echo "Terraform remote S3 backend config for terraform state ..."
+	terraform remote config -backend=s3 \
+	  -backend-config="bucket=$(TFSTATE_BUCKET)" \
+	  -backend-config="key=$(TFSTATE_FILE)"
+
+plan: config
+	@echo "Terraform get, plan ..."
+	terraform get
+	terraform plan
+
+apply: config
+	terraform apply
+	rm -f .terraform/terraform.tfstate*
+
+
+output: config
+	terraform show
+	rm -f .terraform/terraform.tfstate*
+
+destroy: plan
+	terraform destroy
+	rm -rf .terraform

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # terraform-remote-state
 This repository enables locking and unlocking of terraform remote state file for AWS.
+
+Pre Requisites:
+Before running the 'terraform.py' ensure the following resources on your system.
+1. Latest terraform build
+2. AWS credentials are sources as environment variables:
+      export AWS_DEFAULT_REGION=<Region name>
+      export AWS_ACCESS_KEY_ID=<Your access key id>
+      export AWS_SECRET_ACCESS_KEY=<Your secret key id>
+      export S3_BUCKET_NAME=pubc-tfstate
+      export DB_DOMAIN_NAME=tfstate
+3. Run 'pip install -r requirements.txt' (To install dependencies)
+4. The Terraform template file is in the same directory as the resository.
+
+To run terraform.py:
+python terraform.py <cmd>
+
+For terraform plan : python terraform.py plan
+For terraform apply : python terraform.py deploy
+For terraform destroy: python terraform.py destroy.
+
+To use this file as a library:
+import terraform
+
+To call terraform run:
+terraform.run_command('plan/apply/destroy')

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,8 @@
+resource "aws_instance" "test" {
+  count="1"
+  ami = "<test-ami>"
+  instance_type = "t2.micro"
+  tags {
+    Name = "test-vm"
+  }
+}

--- a/terraform.py
+++ b/terraform.py
@@ -1,0 +1,153 @@
+# Please read the README.md before using this file.
+
+import boto
+import time
+import uuid
+import random
+import os
+import urllib2
+import subprocess
+from threading import Thread
+from boto.s3.connection import S3Connection, Location
+from boto.s3.key import Key
+from boto.iam.connection import IAMConnection
+
+def get_user_name(accessKey,secretKey):
+    """ Connects to the IAM
+        Gets the username for given access key and secret key """
+    try:
+        acc = IAMConnection(accessKey,secretKey)
+        result = acc.get_user()
+        uname = result['get_user_response']['get_user_result']['user']['user_name']
+        return uname
+    except Exception as e:
+        print "Exception occurred while fetching IAM info: ", e.message
+
+def connect_db(accessKey,secretKey):
+    """ Connects to the AWS Simple DB instance.
+        If not present, throws exception."""
+    try:
+        db = boto.connect_sdb(accessKey, secretKey)
+    except Exception as e:
+        print "Exception occurred in connect_sdb:", e.message
+        return e
+    return db
+
+def get_domain(lockDomain, db):
+    """ Gets the domain (table) from the Simple DB instance.
+        If not present, creates the simple DB domain.
+        The domain(table) is used to save the lock info (lockID, userID) """
+    try:
+        domain = db.get_domain(lockDomain)
+    except Exception as e:
+        #self.domain = None
+        if e.message == "The specified domain does not exist.":
+            domain = db.create_domain(lockDomain)
+        else:
+            print "Exception occurred in db_getdomain: ", e.message
+            #continue
+    return domain
+
+def S3_connection(accessKey,secretKey,region):
+    """ Connects to the AWS S3 storage for given credentials.
+        If connection fails, throws an exception"""
+    try:
+        s3 = S3Connection(accessKey, secretKey, host='s3.'+region+'.amazonaws.com')
+    except Exception as e:
+        #self.s3 = None
+        print "Exception occurred in S3Connection:", e.message
+        #continue
+    return s3
+
+def create_bucket(s3,s3bucket,region_name,validate=False):
+    """ Tries to get bucket info from S3.
+        If bucket not present, creates a bucket """
+    location_dict = vars(Location)
+    location_name = 'Location.'+''.join([k for k,v in location_dict.items() if v == region_name])
+    try:
+        bucket = s3.get_bucket(s3bucket)
+    except boto.exception.S3ResponseError, e:
+        if e.message == "The specified bucket does not exist":
+            bucket = s3.create_bucket(s3bucket, location=eval(location_name))
+    return bucket
+
+
+class repository:
+    def __init__(self, accessKey, secretKey, lockDomain, s3bucket,region):
+        # Create a connection to the simpleDB instance
+        self.db = connect_db(accessKey, secretKey)
+        self.domain = get_domain(lockDomain, self.db)
+        self.s3 = S3_connection(accessKey,secretKey,region)
+        self.bucket = create_bucket(self.s3,s3bucket,region,validate=False)
+
+    def acquireLock(self, id, uname):
+        """ Acquires lock and returns a lockId that can be passed to releaseLock()
+              id - ID of object to lock - can be any string up to 256 chars in length
+              uname - USERID of the user who is running the thread.
+              Returns lockId (string) if lock is acquired.  If lock cannot be acquired, throws SystemError"""
+        lockId  = uuid.uuid4()
+        attribs = self.db.get_attributes(self.domain, id, consistent_read=True)
+        if attribs.has_key('userid'):
+            raise SystemError("Unable to obtain lock for: %s\t as User %s is running" % (id, attribs['userid']))
+        try:
+            if self.db.put_attributes(self.domain, id, {'lockId' : lockId , 'userid' : uname}, replace=False, expected_value=['lockId', False]):
+                return lockId
+            print "Lock acquired by ", uname
+        except boto.exception.SDBResponseError, e:
+            if e.status != 404 and e.status != 409:
+                raise e
+
+    def releaseLock(self, uname, id, lockId):
+        """ Releases previously acquired lock. id - ID of object to lock.  lockId - Lock ID returned from acquireLock() """
+        print "Releasing the Lock acquired by User: %s, on Object: %s, ID: %s)" % (uname, id, lockId)
+        try:
+            return self.db.delete_attributes(self.domain, id, [ 'lockId', 'userid' ], expected_value=['lockId', lockId])
+        except boto.exception.SDBResponseError, e:
+            if e.status == 404 or e.status == 409:
+                return False
+            else:
+                raise e
+
+class Runner(Thread):
+    def __init__(self, repository, command, uname):
+        Thread.__init__(self)
+        self.repository = repository
+        self.id = 'terraform.tfstate'
+        self.command = command
+        self.uname = uname
+
+    def run(self):
+        r = self.repository
+        id = self.id
+        try:
+            lockId = r.acquireLock(id,self.uname) #Acquires lock on the id.
+            self.updateS3Obj() #Calls terraform run command
+            r.releaseLock(self.uname, id, lockId) #When complete, releases the lock on the id.
+        except Exception as e:
+            print e.message
+
+    def updateS3Obj(self):
+        r = self.repository
+        id = self.id
+        p = subprocess.Popen(['make', self.command], cwd=os.getcwd())
+        p.wait()
+
+def run_command(arg):
+    command = arg
+    os.environ['S3_USE_SIGV4'] = 'True'
+    access_key = os.environ['AWS_ACCESS_KEY_ID']
+    secret_key = os.environ['AWS_SECRET_ACCESS_KEY']
+    domain = os.environ['DB_DOMAIN_NAME']
+    bucket = os.environ['S3_BUCKET_NAME']+'-'+os.environ['AWS_DEFAULT_REGION']
+    uname = get_user_name(access_key, secret_key)
+    region = os.environ['AWS_DEFAULT_REGION']
+
+    r = repository(access_key, secret_key, domain, bucket, region)
+    runner = Runner(r,command,uname)
+    runner.start()
+    runner.join()
+    print "Finished Execution!"
+
+if __name__ == "__main__":
+    import sys
+    run_command(sys.argv[1])


### PR DESCRIPTION
This patch adds a python script which uses AWS simpleDB for
implementing lock/unlock feature of terraform remote state file.

When a user is running terraform, the simpleDB will have the
entires {lockID, userID} for the state file object.
This entry will prevent another user attempting to run terraform.
Once the terraform commands finishes, the entry is deleted from
the DB.

Change-Id: Ie3ac2fdcbec78a3740d34fcda772b5ca771402ee
